### PR TITLE
修改文档中的描述问题

### DIFF
--- a/_posts/2014-09-12-hurlex-7.md
+++ b/_posts/2014-09-12-hurlex-7.md
@@ -38,7 +38,6 @@ Interrupt Controller，PIC）。关于8259A PIC的资料网上铺天盖地的，
 
     #ifndef INCLUDE_IDT_H_
     #define INCLUDE_IDT_H_
-    
     #include "types.h"
     
     // 初始化中断描述符表

--- a/_posts/2014-09-12-hurlex-7.md
+++ b/_posts/2014-09-12-hurlex-7.md
@@ -28,7 +28,9 @@ Interrupt Controller，PIC）。关于8259A PIC的资料网上铺天盖地的，
 中断的实现
 ----------
 
-我们的重点是保护模式下的中断处理。中断处理程序是运行在ring0层的，这就意味着中断处理程序拥有着系统的全部权限，仿照内存段描述符表的思路，Intel设置了一个叫做中断描述符表（IDT, Interrupt Descriptor Table）的东西，和段描述符表一样放置在主存中，类似地，也有一个中断描述符表寄存器（IDTR）记录这个表的起始地址。那么下文的重点就是这个中断描述符的结构和设置方法了，其实这里很类似GDT的那一套过程，我们先给出中断描述符表的结构：[^3]
+我们的重点是保护模式下的中断处理。中断处理程序是运行在ring0层的，这就意味着中断处理程序拥有着系统的全部权限，仿照内存段描述符表的思路，Intel设置了一个叫做中断描述符表（IDT, Interrupt Descriptor Table）的东西，和段描述符表一样放置在主存中，类似地，也有一个中断描述符表寄存器（IDTR）记录这个表的起始地址。IDT 表中可以存放三种类型的门描述符：中断门描述符、陷阱门描述符、任务门描述符。
+
+那么下文的重点就是这些中断描述符的结构和设置方法了，其实这里很类似GDT的那一套过程，我们先给出中断门描述符的结构：[^3]
 
 ![中断描述符的格式](https://raw.githubusercontent.com/hurley25/wiki/gh-pages/_posts/picture/chapt7/interrupt_gate.png)
 
@@ -36,12 +38,12 @@ Interrupt Controller，PIC）。关于8259A PIC的资料网上铺天盖地的，
 
     #ifndef INCLUDE_IDT_H_
     #define INCLUDE_IDT_H_
-
+    
     #include "types.h"
-
+    
     // 初始化中断描述符表
     void init_idt();
-
+    
     // 中断描述符
     typedef
     struct idt_entry_t {
@@ -51,14 +53,14 @@ Interrupt Controller，PIC）。关于8259A PIC的资料网上铺天盖地的，
         uint8_t  flags;          // 一些标志，文档有解释
         uint16_t base_hi;        // 中断处理函数地址 31 ～ 16 位
     }__attribute__((packed)) idt_entry_t;
-
+    
     // IDTR
     typedef
     struct idt_ptr_t {
         uint16_t limit;     // 限长
         uint32_t base;      // 基址
     } __attribute__((packed)) idt_ptr_t;
-
+    
     #endif  // INCLUDE_IDT_H_
 
 之前我们建立了中断的概念并且介绍了描述符表的结构，接下来我们细化CPU处理中断的过程，首先是起始过程，也就是从CPU发现中断事件后，打断当前程序或任务的执行，根据某种机制跳转到中断处理函数去执行的过程：
@@ -105,16 +107,16 @@ CPU在发生中断的时候是按照上问所描述的过程执行的，那操�
         uint32_t useresp;
         uint32_t ss;
     } pt_regs;
-
+    
     // 定义中断处理函数指针
     typedef void (*interrupt_handler_t)(pt_regs *);
-
+    
     // 注册一个中断处理函数
     void register_interrupt_handler(uint8_t n, interrupt_handler_t h);
-
+    
     // 调用中断处理函数
     void isr_handler(pt_regs *regs);
-
+    
     // 声明中断处理函数 0 ~ 19 属于 CPU 的异常中断
     // ISR:中断服务程序(interrupt service routine)
     void isr0();        // 0 #DE 除 0 异常 
@@ -137,7 +139,7 @@ CPU在发生中断的时候是按照上问所描述的过程执行的，那操�
     void isr17();       // 17 #AC 对齐检查 
     void isr18();       // 18 #MC 机器检查 
     void isr19();       // 19 #XM SIMD(单指令多数据)浮点异常
-
+    
     // 20 ~ 31 Intel 保留
     void isr20();
     void isr21();
@@ -151,7 +153,7 @@ CPU在发生中断的时候是按照上问所描述的过程执行的，那操�
     void isr29();
     void isr30();
     void isr31();
-
+    
     // 32 ~ 255 用户自定义异常
     void isr255();
 
@@ -169,7 +171,7 @@ CPU在发生中断的时候是按照上问所描述的过程执行的，那操�
         push %1              ; push 中断号
         jmp isr_common_stub
     %endmacro
-
+    
     ; 用于有错误代码的中断
     %macro ISR_ERRCODE 1
     [GLOBAL isr%1]
@@ -178,7 +180,7 @@ CPU在发生中断的时候是按照上问所描述的过程执行的，那操�
         push %1              ; push 中断号
         jmp isr_common_stub
     %endmacro
-
+    
     ; 定义中断处理函数
     ISR_NOERRCODE  0    ; 0 #DE 除 0 异常
     ISR_NOERRCODE  1    ; 1 #DB 调试异常
@@ -200,7 +202,7 @@ CPU在发生中断的时候是按照上问所描述的过程执行的，那操�
     ISR_ERRCODE   17    ; 17 #AC 对齐检查 
     ISR_NOERRCODE 18    ; 18 #MC 机器检查 
     ISR_NOERRCODE 19    ; 19 #XM SIMD(单指令多数据)浮点异常
-
+    
     ; 20 ~ 31 Intel 保留
     ISR_NOERRCODE 20
     ISR_NOERRCODE 21
@@ -272,22 +274,22 @@ interrupt和中断号码。
     #include "string.h"
     #include "debug.h"
     #include "idt.h"
-
+    
     // 中断描述符表
     idt_entry_t idt_entries[256];
-
+    
     // IDTR
     idt_ptr_t idt_ptr;
-
+    
     // 中断处理函数的指针数组
     interrupt_handler_t interrupt_handlers[256];
-
+    
     // 设置中断描述符
     static void idt_set_gate(uint8_t num, uint32_t base, uint16_t sel, uint8_t flags);
-
+    
     // 声明加载 IDTR 的函数
     extern void idt_flush(uint32_t);
-
+    
     // 初始化中断描述符表
     void init_idt()
     {   
@@ -297,7 +299,7 @@ interrupt和中断号码。
         idt_ptr.base  = (uint32_t)&idt_entries;
         
         bzero((uint8_t *)&idt_entries, sizeof(idt_entry_t) * 256);
-
+    
         // 0-32:  用于 CPU 的中断处理
         idt_set_gate( 0, (uint32_t)isr0,  0x08, 0x8E);
         idt_set_gate( 1, (uint32_t)isr1,  0x08, 0x8E);
@@ -331,23 +333,23 @@ interrupt和中断号码。
         idt_set_gate(29, (uint32_t)isr29, 0x08, 0x8E);
         idt_set_gate(30, (uint32_t)isr30, 0x08, 0x8E);
         idt_set_gate(31, (uint32_t)isr31, 0x08, 0x8E);
-
+    
         // 255 将来用于实现系统调用
         idt_set_gate(255, (uint32_t)isr255, 0x08, 0x8E);
-
+    
         // 更新设置中断描述符表
         idt_flush((uint32_t)&idt_ptr);
     }
-
+    
     // 设置中断描述符
     static void idt_set_gate(uint8_t num, uint32_t base, uint16_t sel, uint8_t flags)
     {
         idt_entries[num].base_lo = base & 0xFFFF;
         idt_entries[num].base_hi = (base >> 16) & 0xFFFF;
-
+    
         idt_entries[num].sel     = sel;
         idt_entries[num].always0 = 0;
-
+    
         // 先留下 0x60 这个魔数，以后实现用户态时候
         // 这个与运算可以设置中断门的特权级别为 3
         idt_entries[num].flags = flags;  // | 0x60
@@ -367,19 +369,19 @@ interrupt和中断号码。
     #include "debug.h"
     #include "gdt.h"
     #include "idt.h"
-
+    
     int kern_entry()
     {
         init_debug();
         init_gdt();
         init_idt();
-
+    
         console_clear();
         printk_color(rc_black, rc_green, "Hello, OS kernel!\n");
-
+    
         asm volatile ("int $0x3");
         asm volatile ("int $0x4");
-
+    
         return 0;
     }
 

--- a/_posts/2014-09-12-hurlex-7.md
+++ b/_posts/2014-09-12-hurlex-7.md
@@ -28,9 +28,7 @@ Interrupt Controller，PIC）。关于8259A PIC的资料网上铺天盖地的，
 中断的实现
 ----------
 
-我们的重点是保护模式下的中断处理。中断处理程序是运行在ring0层的，这就意味着中断处理程序拥有着系统的全部权限，仿照内存段描述符表的思路，Intel设置了一个叫做中断描述符表（IDT, Interrupt Descriptor Table）的东西，和段描述符表一样放置在主存中，类似地，也有一个中断描述符表寄存器（IDTR）记录这个表的起始地址。IDT 表中可以存放三种类型的门描述符：中断门描述符、陷阱门描述符、任务门描述符。
-
-那么下文的重点就是这些中断描述符的结构和设置方法了，其实这里很类似GDT的那一套过程，我们先给出中断门描述符的结构：[^3]
+我们的重点是保护模式下的中断处理。中断处理程序是运行在ring0层的，这就意味着中断处理程序拥有着系统的全部权限，仿照内存段描述符表的思路，Intel设置了一个叫做中断描述符表（IDT, Interrupt Descriptor Table）的东西，和段描述符表一样放置在主存中，类似地，也有一个中断描述符表寄存器（IDTR）记录这个表的起始地址。IDT 表中可以存放三种类型的门描述符：中断门描述符、陷阱门描述符、任务门描述符。那么下文的重点就是这些中断描述符的结构和设置方法了，其实这里很类似GDT的那一套过程，我们先给出中断门描述符的结构：[^3]
 
 ![中断描述符的格式](https://raw.githubusercontent.com/hurley25/wiki/gh-pages/_posts/picture/chapt7/interrupt_gate.png)
 
@@ -38,6 +36,7 @@ Interrupt Controller，PIC）。关于8259A PIC的资料网上铺天盖地的，
 
     #ifndef INCLUDE_IDT_H_
     #define INCLUDE_IDT_H_
+    
     #include "types.h"
     
     // 初始化中断描述符表


### PR DESCRIPTION
增加 IDT 内描述符的区分；修改"中断描述符表的结构"为"终端门描述符"的结构